### PR TITLE
SecurityConfig - 토큰 헤더명 변경 / Login시 responseBody에 사용자 전화번호 추가

### DIFF
--- a/houssg/src/main/java/ssg/com/houssg/config/SecurityConfig.java
+++ b/houssg/src/main/java/ssg/com/houssg/config/SecurityConfig.java
@@ -49,8 +49,8 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList("*"));  
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET","POST", "PATCH", "DELETE"));
-        configuration.addExposedHeader("authorization");
-        configuration.addExposedHeader("Refreshtoken");
+        configuration.addExposedHeader("Authorization");
+        configuration.addExposedHeader("RefreshToken");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();  
         source.registerCorsConfiguration("/**", configuration);

--- a/houssg/src/main/java/ssg/com/houssg/controller/UserController.java
+++ b/houssg/src/main/java/ssg/com/houssg/controller/UserController.java
@@ -69,10 +69,11 @@ public class UserController {
 			 Map<String, Object> responseMap = new HashMap<>();
 		        responseMap.put("message", "로그인 성공");
 		        responseMap.put("nickname", dto.getNickname()); // 닉네임 추가
-			
+		        responseMap.put("phone", dto.getPhonenumber()); // 휴대폰 번호 추가
+		        
 			HttpHeaders headers = new HttpHeaders();
 	        headers.add("Authorization", "Bearer " + token);
-	        headers.add("Refresh-Token" , refreshToken);
+	        headers.add("RefreshToken" , refreshToken);
 	        tokenService.storeRefreshToken(refreshToken, user);
 	        
 	        System.out.println("로그인 성공" + new Date());


### PR DESCRIPTION
## 개요

-  SecurityConfig - 토큰 헤더명 변경 / Login시 responseBody에 사용자 전화번호 추가

## 작업사항

1.  SecurityConfig - 토큰 헤더명 변경
1. Login시 responseBody에 사용자 전화번호 추가

## 변경사항 

1.      configuration.addExposedHeader("Authorization");
        configuration.addExposedHeader("RefreshToken");
1.     Map<String, Object> responseMap = new HashMap<>();
		        responseMap.put("message", "로그인 성공");
		        responseMap.put("nickname", dto.getNickname()); // 닉네임 추가
		        responseMap.put("phone", dto.getPhonenumber()); // 휴대폰 번호 추가

## 미완성 사항

1.
1.

## Issue 번호

- #69 
