### PR TITLE
sms API - 세션아이디 항목을 휴대폰번호로 변경

### DIFF
--- a/houssg/src/main/java/ssg/com/houssg/controller/ReservationController.java
+++ b/houssg/src/main/java/ssg/com/houssg/controller/ReservationController.java
@@ -1,0 +1,5 @@
+package ssg.com.houssg.controller;
+
+public class ReservationController {
+
+}

--- a/houssg/src/main/java/ssg/com/houssg/controller/SmsController.java
+++ b/houssg/src/main/java/ssg/com/houssg/controller/SmsController.java
@@ -56,20 +56,20 @@ public class SmsController {
 	
 
 	@PostMapping("/check") // 인증번호 비교 확인
-	public ResponseEntity<String> checkVerificationCode(@RequestParam("sessionId") String sessionId, @RequestParam("verificationCode") String Code) {
+	public ResponseEntity<String> checkVerificationCode(@RequestParam("phoneNumber") String phoneNumber, @RequestParam("verificationCode") String Code) {
 		System.out.println(Code);
 		
 		// VerificationCodeValidator 클래스의 인스턴스 생성
 	    VerificationCodeValidator validator = new VerificationCodeValidator(smsCodeDao);
 
 	    // 생성한 인스턴스를 사용하여 isValidVerificationCode 메서드 호출
-	    boolean isValid = validator.isValidVerificationCode(sessionId ,Code);
+	    boolean isValid = validator.isValidVerificationCode(phoneNumber ,Code);
 		System.out.println("입력받은 값 : "  + Code);
 		if (isValid) {
 			System.out.println(isValid);
 			
 			// 인증이 완료된 후에 삭제
-			verificationCodeCleanupService.deleteSuccessVerificationCodes(sessionId);
+			verificationCodeCleanupService.deleteSuccessVerificationCodes(phoneNumber);
 
 			return ResponseEntity.ok("인증되었습니다.");
 		} else {
@@ -79,13 +79,13 @@ public class SmsController {
 	}
 
 	@PostMapping("/check-findid") // 인증번호 비교 확인
-	public ResponseEntity<Object> findId(@RequestParam("sessionId") String sessionId,
-			@RequestParam("verificationCode") String Code, @RequestParam("phone_number") String phoneNumber) {
+	public ResponseEntity<Object> findId(@RequestParam("phoneNumber") String phoneNumber,
+			@RequestParam("verificationCode") String Code) {
 		// VerificationCodeValidator 클래스의 인스턴스 생성
 	    VerificationCodeValidator validator = new VerificationCodeValidator(smsCodeDao); 
 
 	    // 생성한 인스턴스를 사용하여 isValidVerificationCode 메서드 호출
-	    boolean isValid = validator.isValidVerificationCode(sessionId, Code);
+	    boolean isValid = validator.isValidVerificationCode(phoneNumber, Code);
 
 		if (!isValid) {
 			return ResponseEntity.badRequest().body("유효하지 않는 인증번호입니다.");
@@ -103,7 +103,7 @@ public class SmsController {
 
 		if (foundId != null) {
 			// 인증이 완료된 후에 삭제
-			verificationCodeCleanupService.deleteSuccessVerificationCodes(sessionId);
+			verificationCodeCleanupService.deleteSuccessVerificationCodes(phoneNumber);
 			return ResponseEntity.ok(foundId);
 		} else {
 			// 해당 휴대폰번호로 가입한 아이디가 없습니다

--- a/houssg/src/main/java/ssg/com/houssg/dao/ReservationDao.java
+++ b/houssg/src/main/java/ssg/com/houssg/dao/ReservationDao.java
@@ -1,0 +1,5 @@
+package ssg.com.houssg.dao;
+
+public interface ReservationDao {
+
+}

--- a/houssg/src/main/java/ssg/com/houssg/dao/SmsCodeDao.java
+++ b/houssg/src/main/java/ssg/com/houssg/dao/SmsCodeDao.java
@@ -13,11 +13,11 @@ public interface SmsCodeDao {
 	 void saveCode(SmsCodeDto smsCodeDto);
 	 
 	 // 세션 아이디로 저장된 정보 불러오기
-	 SmsCodeDto getCodeBySessionId(String sessionId);
+	 SmsCodeDto getCodeByphoneNumber(String phoneNumber);
 	
 	 // 1시간 주기마다 만료기간이 지난 코드 삭제
 	 void deleteExpiredVerificationCodes();
 	 
 	 // 인증완료된 인증번호 삭제
-	 void deleteSuccessVerificationCodes(String sessionId);
+	 void deleteSuccessVerificationCodes(String phoneNumber);
 }

--- a/houssg/src/main/java/ssg/com/houssg/dto/ReservationDto.java
+++ b/houssg/src/main/java/ssg/com/houssg/dto/ReservationDto.java
@@ -1,0 +1,5 @@
+package ssg.com.houssg.dto;
+
+public class ReservationDto {
+
+}

--- a/houssg/src/main/java/ssg/com/houssg/dto/SmsCodeDto.java
+++ b/houssg/src/main/java/ssg/com/houssg/dto/SmsCodeDto.java
@@ -3,33 +3,39 @@ package ssg.com.houssg.dto;
 import java.util.Date;
 
 public class SmsCodeDto {
-	
-	private String sessionId;
+
+	private String phoneNumber;
 	private String verificationCode;
 	private Date expirationTime;
-	
-	public String getSessionId() {
-		return sessionId;
+
+	public String getPhoneNumber() {
+		return phoneNumber;
 	}
-	public void setSessionId(String sessionId) {
-		this.sessionId = sessionId;
+
+	public void setPhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
 	}
+
 	public String getVerificationCode() {
 		return verificationCode;
 	}
+
 	public void setVerificationCode(String verificationCode) {
 		this.verificationCode = verificationCode;
 	}
+
 	public Date getExpirationTime() {
 		return expirationTime;
 	}
+
 	public void setExpirationTime(Date expirationTime) {
 		this.expirationTime = expirationTime;
 	}
+
 	@Override
 	public String toString() {
-		return "SmsCodeDto [sessionId=" + sessionId + ", verificationCode=" + verificationCode + ", expirationTime="
+		return "SmsCodeDto [phoneNumber=" + phoneNumber + ", verificationCode=" + verificationCode + ", expirationTime="
 				+ expirationTime + "]";
 	}
-	
+
 }

--- a/houssg/src/main/java/ssg/com/houssg/service/SmsService.java
+++ b/houssg/src/main/java/ssg/com/houssg/service/SmsService.java
@@ -55,12 +55,10 @@ public class SmsService {
 		// 6자리 난수 생성
 		String verificationCode = generateVerificationCode();
 
-		// 세션 아이디 생성
-		String sessionId = generateSessionId();
 		
-		// 세션 대신 DB에 세션 아이디, 인증 번호 및 유효 시간 저장
+		// DB에 휴대폰번호, 인증 번호 및 유효 시간 저장
 		SmsCodeDto smsCodeDto = new SmsCodeDto();
-		smsCodeDto.setSessionId(sessionId); // 세션 아이디 생성 메서드 필요
+		smsCodeDto.setPhoneNumber(recipientPhoneNumber);
 		smsCodeDto.setVerificationCode(verificationCode);
 		smsCodeDto.setExpirationTime(new Date(System.currentTimeMillis() + 5 * 60 * 1000)); // 5분 유효 시간 설정
 
@@ -94,7 +92,6 @@ public class SmsService {
 		SmsResponseDto smsResponse = restTemplate.postForObject(
 				new URI("https://sens.apigw.ntruss.com/sms/v2/services/" + this.serviceId + "/messages"), body,
 				SmsResponseDto.class);
-		smsResponse.setSessionId(sessionId);
 		return smsResponse;
 	}
 

--- a/houssg/src/main/java/ssg/com/houssg/util/VerificationCodeValidator.java
+++ b/houssg/src/main/java/ssg/com/houssg/util/VerificationCodeValidator.java
@@ -14,7 +14,7 @@ public class VerificationCodeValidator {
     public  boolean isValidVerificationCode(String sessionId, String Code) {
 
     	// DB에서 해당 세션 아이디에 저장된 SMS 코드 정보를 가져옴
-        SmsCodeDto smsCodeDto = smsCodeDao.getCodeBySessionId(sessionId);
+        SmsCodeDto smsCodeDto = smsCodeDao.getCodeByphoneNumber(sessionId);
         
         if (smsCodeDto == null) {
             // 해당 세션 아이디에 대한 정보가 DB에 없음
@@ -22,7 +22,7 @@ public class VerificationCodeValidator {
         }
 
         // DB에 저장된 세션 아이디와 인증번호를 클라이언트에서 받은 값과 비교
-        if (sessionId.equals(smsCodeDto.getSessionId()) && Code.equals(smsCodeDto.getVerificationCode())) {
+        if (sessionId.equals(smsCodeDto.getPhoneNumber()) && Code.equals(smsCodeDto.getVerificationCode())) {
             // 세션 아이디와 인증번호가 일치
 
             // 유효 시간 체크

--- a/houssg/src/main/resources/sqls/SmsCode.xml
+++ b/houssg/src/main/resources/sqls/SmsCode.xml
@@ -6,17 +6,17 @@
 	<!-- 세션아이디 + 인증번호를 유효기간과 함께 저장 -->
 	<insert id="saveCode"
 		parameterType="ssg.com.houssg.dto.SmsCodeDto">
-		insert into sms_code(session_id, verification_code,
+		insert into sms_code(phone_number, verification_code,
 		expiration_time)
-		values (#{sessionId}, #{verificationCode},
+		values (#{phoneNumber}, #{verificationCode},
 		#{expirationTime})
 	</insert>
 
 
 	<!-- 세션 아이디로 SMS 코드 정보 조회 -->
-	<select id="getCodeBySessionId" parameterType="java.lang.String"
+	<select id="getCodeByphoneNumber" parameterType="java.lang.String"
 		resultType="ssg.com.houssg.dto.SmsCodeDto">
-		SELECT * FROM sms_code WHERE session_id = #{sessionId}
+		SELECT * FROM sms_code WHERE phone_number = #{phoneNumber}
 	</select>
 	
 	<!-- 만료된 인증 코드를 삭제하는 쿼리문 -->
@@ -28,7 +28,7 @@
     <!-- 인증완료된 인증 코드를 삭제하는 쿼리문 -->
     <delete id="deleteSuccessVerificationCodes">
         DELETE FROM sms_code
-        WHERE session_id = #{sessionId};
+        WHERE phone_number = #{phoneNumber};
     </delete>
     
 </mapper>


### PR DESCRIPTION
## 개요

- sms API - 세션아이디 항목을 휴대폰번호로 변경

## 작업사항

1. 기존 세션아이디를 생성하셔 [세션아이디, 인증번호, 만료기간] 을 저장
2. 세션아이디와 인증번호 일치여부 + 만료기한 여부 확인 후 인증
3. 세션아이디가 불필요한 데이터라 판단되어 전화번호로 변경

## 변경사항

1. 세션아이디 항목을 휴대폰번호로 변경
1.

## 미완성 사항

1.
1.

## Issue 번호

- #71 
