### PR TITLE
Update: 환불수수료 계산 시 -1일 경우에만 예약취소가 불가능하게 수정함

### DIFF
--- a/houssg/src/main/java/ssg/com/houssg/controller/ReservationController.java
+++ b/houssg/src/main/java/ssg/com/houssg/controller/ReservationController.java
@@ -210,8 +210,8 @@ public class ReservationController {
 		String couponNumber = reservation.getCouponNumber();
 		int paymentAmount = reservation.getPaymentAmount();
 
-		// 2. 예약 취소
-		reservationService.cancelReservationByUser(reservationNumber);
+//		// 2. 예약 취소
+//		reservationService.cancelReservationByUser(reservationNumber);
 
 		// 3. 예약 취소 - 포인트 반환
 		reservationService.returnUsePoint(id, usePoint);
@@ -376,6 +376,9 @@ public class ReservationController {
 		String couponNumber = reservation.getCouponNumber();
 		int paymentAmount = reservation.getPaymentAmount();
 
+		// 2. 사업자 - 예약 취소
+		reservationService.cancelReservationByOwner(reservationNumber);
+		
 		// 3. 사업자 - 예약 취소 - 포인트 반환
 		reservationService.returnUsePoint(id, usePoint);
 
@@ -385,8 +388,6 @@ public class ReservationController {
 		// 5. 사업자 - 예약 취소 - 취소 리워드 계산
 		reservationService.pointRewardsForCancel(reservationNumber, paymentAmount);
 		
-		// 2. 사업자 - 예약 취소
-		reservationService.cancelReservationByOwner(reservationNumber);
 
 		// request의 예약번호를 통해 reservation 정보 조회
 		ReservationForLmsDto LmsInfo = reservationService.getReservationInfoForGuest(reservationNumber);

--- a/houssg/src/main/java/ssg/com/houssg/service/ReservationService.java
+++ b/houssg/src/main/java/ssg/com/houssg/service/ReservationService.java
@@ -228,10 +228,13 @@ public class ReservationService {
 		int daysUntilCheckIn = period.getDays();
 
 		if (daysUntilCheckIn >= 7) {
+			dao.cancelReservationByUser(reservationNumber);
 			return 0; // 일주일 전
 		} else if (daysUntilCheckIn >= 5) {
+			dao.cancelReservationByUser(reservationNumber);
 			return (int) (paymentAmount * 0.3); // 5, 6일 전
 		} else if (daysUntilCheckIn >= 2) {
+			dao.cancelReservationByUser(reservationNumber);
 			return (int) (paymentAmount * 0.5); // 2, 3, 4일 전
 		} else {
 			return -1; // 하루 전, 당일 (취소불가)


### PR DESCRIPTION
## 개요

- 환불수수료 계산 시 -1일 경우에만 예약취소가 불가능하게 수정함


## 변경사항

1. 기존 status 변경 코드가 환불수수료 계산 코드 위에 존재했기때문에 환불불가여도 취소가 됐던 점을 환불 수수료가 -1(취소불가)이 나오는 시점에만 status 변경 안되게 수정하였음


## Issue 번호

- #223 
