### PR TITLE
Fix: 어세스토큰 만료시간 1분으로 설정(리프레시 확인위함)

### DIFF
--- a/houssg/src/main/resources/application.properties
+++ b/houssg/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.hikari.password=${DB_PASSWORD}
 
 # JWT 설정
 jwt.secret=${JWT_SECRET}
-jwt.expiration = 7200000
+jwt.expiration = 60000
 #2시간
 jwt.refreshExpiration=604800000
 #7일


### PR DESCRIPTION
## 개요

- 어세스토큰 만료시간 1분으로 설정(리프레시 확인위함)



## 변경사항

1. 어세스토큰 만료시간 1분으로 설정(리프레시 확인위함)
1.


## Issue 번호

- #이슈번호
