### PR TITLE
Update: 어세스 토큰 만료기한 2시간으로 재설정

### DIFF
--- a/houssg/src/main/resources/application.properties
+++ b/houssg/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.hikari.password=${DB_PASSWORD}
 
 # JWT 설정
 jwt.secret=${JWT_SECRET}
-jwt.expiration = 60000
+jwt.expiration = 7200000
 #2시간
 jwt.refreshExpiration=604800000
 #7일


### PR DESCRIPTION
## 개요

- 어세스 토큰 만료기한 2시간으로 재설정

## 작업사항

1. 어세스 토큰 만료기한 2시간으로 재설정

## 변경사항

1. jwt.expiration = 7200000



## Issue 번호

- #이슈번호
